### PR TITLE
Properly check security matches when initializing an ESPDevice

### DIFF
--- a/ESPProvision/ESPDevice.swift
+++ b/ESPProvision/ESPDevice.swift
@@ -386,11 +386,14 @@ public class ESPDevice {
             if security != .unsecure {
                 completionHandler(.failedToConnect(.securityMismatch))
                 return
-            } else if security != .secure {
+            }
+        } else {
+            if security != .secure {
                 completionHandler(.failedToConnect(.securityMismatch))
                 return
             }
         }
+
         switch security {
         case .secure:
             var pop:String!


### PR DESCRIPTION
Fixes [this issue](https://github.com/espressif/esp-idf-provisioning-ios/issues/15)

The check for `.secure` security level for the device to initialize should not be within if-block that is entered if the device advertises a `no_sec` capability, indicating that there isn't any network security.