### PR TITLE
Fix re-sending config data

### DIFF
--- a/ESPProvision/Transport/ESPBleTransport.swift
+++ b/ESPProvision/Transport/ESPBleTransport.swift
@@ -333,6 +333,7 @@ extension ESPBleTransport: CBPeripheralDelegate {
         
         ESPLog.log("Writing value for characterisitic \(characteristic)")
         guard error == nil else {
+            transportToken.signal()
             currentRequestCompletionHandler?(nil, error)
             return
         }
@@ -343,6 +344,7 @@ extension ESPBleTransport: CBPeripheralDelegate {
     func peripheral(_: CBPeripheral, didUpdateValueFor characteristic: CBCharacteristic, error: Error?) {
         ESPLog.log("Updating value for characterisitic \(characteristic)")
         guard error == nil else {
+            transportToken.signal()
             currentRequestCompletionHandler?(nil, error)
             return
         }


### PR DESCRIPTION
## Issue
The current ble connection freezes if you try to connect (establish the session) to the device again.

### Details
- The first time you use `connect` function in. the `ESPDevice`, it works.
- However, if  the completion status is error and if we try to use this function again, the app will freeze.
```
espDevice.connect(delegate: self) { status in
}
```

## Reason
The `DispatchSemaphore` doesn't call `signal()` when it catches errors.

### Details
- Whenever we call `connect` or `sendData` from `ESPDevice`, internally we all `func SendConfigData`
- This function locks the process by `transportToken.wait()`and releases it when the process finishes.
- However, `transportToken.signal()` is not called when the process ends with error.
  - When we call `espressifPeripheral.writeValue` in the function, delegate functions `didWriteValueFor` or `didUpdateValueFor` is called.
  - When it catches errors, it completes with only handler.(without signal())
```
        guard error == nil else {
            currentRequestCompletionHandler?(nil, error)
            return
        }
```


## Solution
Set `transportToken.signal()` in delegate functions `didWriteValueFor` and `didUpdateValueFor` when it catches error.

```
        guard error == nil else {
            transportToken.signal() // This is needed to release Semaphore
            currentRequestCompletionHandler?(nil, error)
            return
        }
```


