### PR TITLE
Crash in the provision function  

### DIFF
--- a/ESPProvision/ESPDevice.swift
+++ b/ESPProvision/ESPDevice.swift
@@ -310,13 +310,11 @@ open class ESPDevice {
     ///                          Parameter of block include status of provision.
     public func provision(ssid: String, passPhrase: String = "", completionHandler: @escaping (ESPProvisionStatus) -> Void) {
         ESPLog.log("Provisioning started.. with ssid:\(ssid) and password:\(passPhrase)")
-        if session == nil, !session.isEstablished {
+        if session == nil || !session.isEstablished {
             completionHandler(.failure(.sessionError))
         } else {
             provisionDevice(ssid: ssid, passPhrase: passPhrase, retryOnce: true, completionHandler: completionHandler)
         }
-      
-        
     }
     
     /// Returns the wireless network IP 4 address after successful provision.


### PR DESCRIPTION
The provision function is crashing is section is nil.

**Details**

- It's a simple fix, the if should be a OR not an AND

<img width="1034" alt="Screen Shot 2022-08-17 at 15 21 25" src="https://user-images.githubusercontent.com/7820354/185216074-5f42c860-7507-41a9-907a-5f3c76d2407b.png">

**Solution**

```swift
public func provision(ssid: String, passPhrase: String = "", completionHandler: @escaping (ESPProvisionStatus) -> Void) {
        ESPLog.log("Provisioning started.. with ssid:\(ssid) and password:\(passPhrase)")
        if session == nil || !session.isEstablished {
            completionHandler(.failure(.sessionError))
        } else {
            provisionDevice(ssid: ssid, passPhrase: passPhrase, retryOnce: true, completionHandler: completionHandler)
        }
}
```

- Replacing `,` with `||`

It's my first contribution, I hope the format of the PR is ok. :slightly_smiling_face:
