### PR TITLE
feat: wpa3 support

### DIFF
--- a/ESPProvision/Proto/wifi_constants.pb.swift
+++ b/ESPProvision/Proto/wifi_constants.pb.swift
@@ -127,6 +127,8 @@ public enum Espressif_WifiAuthMode: SwiftProtobuf.Enum {
     case wpa2Psk // = 3
     case wpaWpa2Psk // = 4
     case wpa2Enterprise // = 5
+    case wpa3Psk // = 6
+    case wpa2Wpa3Psk // = 7
     case UNRECOGNIZED(Int)
 
     public init() {
@@ -141,6 +143,8 @@ public enum Espressif_WifiAuthMode: SwiftProtobuf.Enum {
         case 3: self = .wpa2Psk
         case 4: self = .wpaWpa2Psk
         case 5: self = .wpa2Enterprise
+        case 6: self = .wpa3Psk
+        case 7: self = .wpa2Wpa3Psk
         default: self = .UNRECOGNIZED(rawValue)
         }
     }
@@ -153,6 +157,8 @@ public enum Espressif_WifiAuthMode: SwiftProtobuf.Enum {
         case .wpa2Psk: return 3
         case .wpaWpa2Psk: return 4
         case .wpa2Enterprise: return 5
+        case .wpa3Psk: return 6
+        case .wpa2Wpa3Psk: return 7
         case let .UNRECOGNIZED(i): return i
         }
     }
@@ -169,6 +175,8 @@ public enum Espressif_WifiAuthMode: SwiftProtobuf.Enum {
             .wpa2Psk,
             .wpaWpa2Psk,
             .wpa2Enterprise,
+            .wpa3Psk,
+            .wpa2Wpa3Psk,
         ]
     }
 
@@ -222,6 +230,8 @@ extension Espressif_WifiAuthMode: SwiftProtobuf._ProtoNameProviding {
         3: .same(proto: "WPA2_PSK"),
         4: .same(proto: "WPA_WPA2_PSK"),
         5: .same(proto: "WPA2_ENTERPRISE"),
+        6: .same(proto: "WPA3_PSK"),
+        7: .same(proto: "WPA2_WPA3_PSK"),
     ]
 }
 

--- a/Example/Legacy/proto/wifi_constants.proto
+++ b/Example/Legacy/proto/wifi_constants.proto
@@ -34,6 +34,8 @@ enum WifiAuthMode {
     WPA2_PSK = 3;
     WPA_WPA2_PSK = 4;
     WPA2_ENTERPRISE = 5;
+    WPA3_PSK = 6;
+    WPA2_WPA3_PSK = 7;
 }
 message WifiConnectedState {
     string ip4_addr = 1;
@@ -42,4 +44,3 @@ message WifiConnectedState {
     bytes bssid = 4;
     int32 channel = 5;
 }
-


### PR DESCRIPTION
The wifi_constants.proto file esp-idf [contains enum values](https://github.com/espressif/esp-idf/blob/master/components/wifi_provisioning/proto/wifi_constants.proto#L22) describing the WPA2/WPA3 mixed mode and the WPA3 SAE modes. This PR appends the missing enum values to the proto file and to the corresponding Swift source.

The lack of theses constants caused issues when scanning for networks when any WPA3 network is available within the range of the ESP device. Connecting to WPA2/WPA3 networks works fine after the fix, with the ESP device selecting the WPA2 mode correctly.

iOS version of https://github.com/espressif/esp-idf-provisioning-android/pull/67