### PR TITLE
Made peripheral in ESPDevice class public

### DIFF
--- a/ESPProvision/ESPDevice.swift
+++ b/ESPProvision/ESPDevice.swift
@@ -98,7 +98,7 @@ open class ESPDevice {
     /// SoftAp transport layer.
     public var espSoftApTransport: ESPSoftAPTransport!
     /// Peripheral object in case of BLE device.
-    var peripheral: CBPeripheral!
+    public var peripheral: CBPeripheral!
     /// Connection status of device.
     var connectionStatus:ESPSessionStatus = .disconnected
     /// Completion handler for scan Wi-Fi list.


### PR DESCRIPTION
### Expose CBPeripheral from ESPDevice for Custom Characteristic Access

Hello,
I'm currently using this library for BLE provisioning and have encountered a limitation: there is no way to access the underlying CBPeripheral from an ESPDevice instance. This restriction prevents me from reading custom BLE characteristics from the peripheral, which is necessary for my use case.

To increase the library's flexibility, I propose adding a public accessor for the BLE peripheral. This change would allow developers to directly access the CBPeripheral, enabling the reading of custom characteristics and enhancing the overall usability of the library.

Thank you for your consideration.

Best regards,
Manuel Baldoni